### PR TITLE
2020 expl3 deprecation removals

### DIFF
--- a/bxjaholiday.sty
+++ b/bxjaholiday.sty
@@ -111,8 +111,8 @@
     {
       \cs_new:Npn \__bxjh_add_jchar_dec:nnn #1#2#3
         {
-          \ptex_kansujichar:D \c_one_int = \ptex_jis:D "#3 \scan_stop:
-          \__bxjh_next:n { \ptex_kansuji:D \c_one_int }
+          \tex_kansujichar:D \c_one_int = \tex_jis:D "#3 \scan_stop:
+          \__bxjh_next:n { \tex_kansuji:D \c_one_int }
         }
     }
 
@@ -120,8 +120,8 @@
     {
       \cs_new:Npn \__bxjh_add_jchar_dec:nnn #1#2#3
         {
-          \ptex_kansujichar:D \c_one_int = \ptex_jis:D "#3 \scan_stop:
-          \__bxjh_next:n { \ptex_kansuji:D \c_one_int }
+          \tex_kansujichar:D \c_one_int = \tex_jis:D "#3 \scan_stop:
+          \__bxjh_next:n { \tex_kansuji:D \c_one_int }
         }
     }
 


### PR DESCRIPTION
Primitive names were standardised to \tex_...:D regardless of engine. The old names \ptex_...:D will be removed by the end of 2019.